### PR TITLE
Implement library app search and detail pages

### DIFF
--- a/library-app/README.md
+++ b/library-app/README.md
@@ -1,46 +1,18 @@
-# Getting Started with Create React App
+# Library App
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This project is a small demo library interface using the Open Library API and Wikipedia.
 
-## Available Scripts
+## Setup
 
-In the project directory, you can run:
+```bash
+npm install
+npm start
+```
 
-### `npm start`
+Runs on `http://localhost:3000`.
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+## Testing
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
+```bash
+npm test
+```

--- a/library-app/src/App.css
+++ b/library-app/src/App.css
@@ -1,38 +1,8 @@
-.App {
-  text-align: center;
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+h1, h2 {
+  margin: 0.5rem 0;
 }

--- a/library-app/src/App.test.tsx
+++ b/library-app/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/library-app/src/App.tsx
+++ b/library-app/src/App.tsx
@@ -1,26 +1,22 @@
 import React from 'react';
-import logo from './logo.svg';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import HomePage from './pages/HomePage';
+import SearchPage from './pages/SearchPage';
+import AdvancedSearchPage from './pages/AdvancedSearchPage';
+import BookDetailPage from './pages/BookDetailPage';
 import './App.css';
 
-function App() {
+const App: React.FC = () => {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <Router>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/search" element={<SearchPage />} />
+        <Route path="/advanced" element={<AdvancedSearchPage />} />
+        <Route path="/book/:key" element={<BookDetailPage />} />
+      </Routes>
+    </Router>
   );
-}
+};
 
 export default App;

--- a/library-app/src/components/BookItem.tsx
+++ b/library-app/src/components/BookItem.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Book } from '../services/openLibrary';
+
+interface Props {
+  book: Book;
+}
+
+const BookItem: React.FC<Props> = ({ book }) => {
+  const coverUrl = book.cover_i
+    ? `https://covers.openlibrary.org/b/id/${book.cover_i}-M.jpg`
+    : undefined;
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '0.5rem', margin: '0.5rem' }}>
+      {coverUrl && <img src={coverUrl} alt={book.title} style={{ width: 80 }} />}
+      <div>
+        <Link to={`/book${book.key}`}>{book.title}</Link>
+        {book.author_name && <div>by {book.author_name.join(', ')}</div>}
+        {book.first_publish_year && <div>First published: {book.first_publish_year}</div>}
+      </div>
+    </div>
+  );
+};
+
+export default BookItem;

--- a/library-app/src/components/BookList.tsx
+++ b/library-app/src/components/BookList.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import BookItem from './BookItem';
+import { Book } from '../services/openLibrary';
+
+interface Props {
+  books: Book[];
+}
+
+const BookList: React.FC<Props> = ({ books }) => {
+  return (
+    <div>
+      {books.map((b) => (
+        <BookItem key={b.key} book={b} />
+      ))}
+    </div>
+  );
+};
+
+export default BookList;

--- a/library-app/src/components/SearchBar.tsx
+++ b/library-app/src/components/SearchBar.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const SearchBar: React.FC = () => {
+  const [query, setQuery] = useState('');
+  const navigate = useNavigate();
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (query.trim()) {
+      navigate(`/search?q=${encodeURIComponent(query)}`);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} style={{ display: 'flex', gap: '0.5rem' }}>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search books..."
+      />
+      <button type="submit">Search</button>
+    </form>
+  );
+};
+
+export default SearchBar;

--- a/library-app/src/index.css
+++ b/library-app/src/index.css
@@ -11,3 +11,13 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+main {
+  padding: 1rem;
+}
+
+@media (max-width: 600px) {
+  img {
+    max-width: 100%;
+  }
+}

--- a/library-app/src/index.tsx
+++ b/library-app/src/index.tsx
@@ -4,16 +4,13 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
-);
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <main>
+      <App />
+    </main>
   </React.StrictMode>
 );
 
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals();

--- a/library-app/src/pages/AdvancedSearchPage.tsx
+++ b/library-app/src/pages/AdvancedSearchPage.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { AdvancedParams, searchAdvanced, Book } from '../services/openLibrary';
+import BookList from '../components/BookList';
+import SearchBar from '../components/SearchBar';
+
+const AdvancedSearchPage: React.FC = () => {
+  const [params, setParams] = useState<AdvancedParams>({});
+  const [books, setBooks] = useState<Book[]>([]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setParams({ ...params, [e.target.name]: e.target.value });
+  };
+
+  const search = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const results = await searchAdvanced(params);
+    setBooks(results);
+  };
+
+  return (
+    <div>
+      <SearchBar />
+      <h2>Advanced Search</h2>
+      <form onSubmit={search} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <input name="title" placeholder="Title" onChange={handleChange} />
+        <input name="author" placeholder="Author" onChange={handleChange} />
+        <input name="subject" placeholder="Subject" onChange={handleChange} />
+        <input name="year" placeholder="First publish year" onChange={handleChange} />
+        <button type="submit">Search</button>
+      </form>
+      <BookList books={books} />
+    </div>
+  );
+};
+
+export default AdvancedSearchPage;

--- a/library-app/src/pages/BookDetailPage.tsx
+++ b/library-app/src/pages/BookDetailPage.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getWork, Work } from '../services/openLibrary';
+import { fetchSummary, WikiSummary } from '../services/wikipedia';
+import SearchBar from '../components/SearchBar';
+
+const BookDetailPage: React.FC = () => {
+  const { key } = useParams<{ key: string }>();
+  const [work, setWork] = useState<Work | null>(null);
+  const [wiki, setWiki] = useState<WikiSummary | null>(null);
+
+  useEffect(() => {
+    if (key) {
+      getWork(`/${key}`).then(setWork);
+    }
+  }, [key]);
+
+  useEffect(() => {
+    if (work?.title) {
+      fetchSummary(work.title).then(setWiki);
+    }
+  }, [work?.title]);
+
+  if (!work) return <div>Loading...</div>;
+
+  const coverUrl = work.covers?.length
+    ? `https://covers.openlibrary.org/b/id/${work.covers[0]}-L.jpg`
+    : undefined;
+
+  return (
+    <div>
+      <SearchBar />
+      <h2>{work.title}</h2>
+      {coverUrl && <img src={coverUrl} alt={work.title} style={{ maxWidth: '200px' }} />}
+      {typeof work.description === 'string' && <p>{work.description}</p>}
+      {wiki?.extract && <p>{wiki.extract}</p>}
+      {wiki?.thumbnail && <img src={wiki.thumbnail.source} alt="Wiki cover" />}
+      {wiki?.content_urls?.desktop?.page && (
+        <p>
+          <a href={wiki.content_urls.desktop.page} target="_blank" rel="noopener noreferrer">
+            Read more on Wikipedia
+          </a>
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default BookDetailPage;

--- a/library-app/src/pages/HomePage.tsx
+++ b/library-app/src/pages/HomePage.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+import { getRecentChanges } from '../services/openLibrary';
+import SearchBar from '../components/SearchBar';
+import { Link } from 'react-router-dom';
+
+const HomePage: React.FC = () => {
+  const [changes, setChanges] = useState<any[]>([]);
+
+  useEffect(() => {
+    getRecentChanges(10).then(setChanges);
+  }, []);
+
+  return (
+    <div>
+      <h1>Library</h1>
+      <SearchBar />
+      <h2>Recent Changes</h2>
+      <ul>
+        {changes.map((c) => (
+          <li key={c.id}>
+            <Link to={`/book${c.data?.key || c.data?.works?.key || ''}`}>{c.comment || c.data?.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default HomePage;

--- a/library-app/src/pages/SearchPage.tsx
+++ b/library-app/src/pages/SearchPage.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { searchBooks, Book } from '../services/openLibrary';
+import SearchBar from '../components/SearchBar';
+import BookList from '../components/BookList';
+
+const SearchPage: React.FC = () => {
+  const [params] = useSearchParams();
+  const [books, setBooks] = useState<Book[]>([]);
+  const query = params.get('q') || '';
+
+  useEffect(() => {
+    if (query) {
+      searchBooks(query).then(setBooks);
+    }
+  }, [query]);
+
+  return (
+    <div>
+      <SearchBar />
+      <h2>Results for "{query}"</h2>
+      <BookList books={books} />
+    </div>
+  );
+};
+
+export default SearchPage;

--- a/library-app/src/services/openLibrary.ts
+++ b/library-app/src/services/openLibrary.ts
@@ -1,0 +1,55 @@
+import axios from 'axios';
+
+export interface Book {
+  key: string;
+  title: string;
+  author_name?: string[];
+  first_publish_year?: number;
+  cover_i?: number;
+}
+
+export interface Work {
+  title: string;
+  description?: string | { value: string };
+  subjects?: string[];
+  covers?: number[];
+  authors?: { author: { key: string } }[];
+}
+
+const BASE_URL = 'https://openlibrary.org';
+
+export async function searchBooks(query: string) {
+  const url = `${BASE_URL}/search.json?q=${encodeURIComponent(query)}`;
+  const res = await axios.get(url);
+  return res.data.docs as Book[];
+}
+
+export interface AdvancedParams {
+  title?: string;
+  author?: string;
+  subject?: string;
+  year?: string;
+}
+
+export async function searchAdvanced(params: AdvancedParams) {
+  const query = new URLSearchParams();
+  if (params.title) query.append('title', params.title);
+  if (params.author) query.append('author', params.author);
+  if (params.subject) query.append('subject', params.subject);
+  if (params.year) query.append('first_publish_year', params.year);
+  const url = `${BASE_URL}/search.json?${query.toString()}`;
+  const res = await axios.get(url);
+  return res.data.docs as Book[];
+}
+
+export async function getRecentChanges(limit = 10) {
+  const url = `${BASE_URL}/recentchanges.json?limit=${limit}`;
+  const res = await axios.get(url);
+  return res.data as any[];
+}
+
+export async function getWork(workKey: string) {
+  const url = `${BASE_URL}${workKey}.json`;
+  const res = await axios.get(url);
+  return res.data as Work;
+}

--- a/library-app/src/services/wikipedia.ts
+++ b/library-app/src/services/wikipedia.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+export interface WikiSummary {
+  extract?: string;
+  content_urls?: { desktop?: { page: string } };
+  thumbnail?: { source: string };
+}
+
+export async function fetchSummary(title: string) {
+  const url = `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}`;
+  const res = await axios.get(url).catch(() => ({ data: {} }));
+  return res.data as WikiSummary;
+}

--- a/library-app/src/utils.test.ts
+++ b/library-app/src/utils.test.ts
@@ -1,0 +1,6 @@
+import { buildQuery } from './utils';
+
+test('buildQuery constructs query string', () => {
+  const q = buildQuery({ title: 'test', author: undefined, year: '2020' });
+  expect(q).toBe('title=test&year=2020');
+});

--- a/library-app/src/utils.ts
+++ b/library-app/src/utils.ts
@@ -1,0 +1,7 @@
+export function buildQuery(params: Record<string, string | undefined>): string {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([k, v]) => {
+    if (v) search.append(k, v);
+  });
+  return search.toString();
+}


### PR DESCRIPTION
## Summary
- initialize a simple library app
- add Open Library and Wikipedia services
- implement search, advanced search, and book details pages
- provide a reusable search bar and book list components
- add small utility with unit test

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6847dfc1c5cc832fb09f18872d8297b5