### PR TITLE
Improve home page with featured books

### DIFF
--- a/library-app/src/App.css
+++ b/library-app/src/App.css
@@ -6,3 +6,30 @@ body {
 h1, h2 {
   margin: 0.5rem 0;
 }
+
+.home-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.book-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+  width: 100%;
+  max-width: 800px;
+}
+
+.book-item {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 0.5rem;
+  text-align: center;
+}
+
+.book-cover {
+  width: 100%;
+  height: auto;
+  margin-bottom: 0.5rem;
+}

--- a/library-app/src/components/BookItem.tsx
+++ b/library-app/src/components/BookItem.tsx
@@ -11,8 +11,8 @@ const BookItem: React.FC<Props> = ({ book }) => {
     ? `https://covers.openlibrary.org/b/id/${book.cover_i}-M.jpg`
     : undefined;
   return (
-    <div style={{ border: '1px solid #ccc', padding: '0.5rem', margin: '0.5rem' }}>
-      {coverUrl && <img src={coverUrl} alt={book.title} style={{ width: 80 }} />}
+    <div className="book-item">
+      {coverUrl && <img className="book-cover" src={coverUrl} alt={book.title} />}
       <div>
         <Link to={`/book${book.key}`}>{book.title}</Link>
         {book.author_name && <div>by {book.author_name.join(', ')}</div>}

--- a/library-app/src/components/BookList.tsx
+++ b/library-app/src/components/BookList.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const BookList: React.FC<Props> = ({ books }) => {
   return (
-    <div>
+    <div className="book-grid">
       {books.map((b) => (
         <BookItem key={b.key} book={b} />
       ))}

--- a/library-app/src/pages/HomePage.tsx
+++ b/library-app/src/pages/HomePage.tsx
@@ -1,27 +1,21 @@
 import React, { useEffect, useState } from 'react';
-import { getRecentChanges } from '../services/openLibrary';
+import { getSubjectBooks, Book } from '../services/openLibrary';
 import SearchBar from '../components/SearchBar';
-import { Link } from 'react-router-dom';
+import BookList from '../components/BookList';
 
 const HomePage: React.FC = () => {
-  const [changes, setChanges] = useState<any[]>([]);
+  const [books, setBooks] = useState<Book[]>([]);
 
   useEffect(() => {
-    getRecentChanges(10).then(setChanges);
+    getSubjectBooks('fantasy', 8).then(setBooks);
   }, []);
 
   return (
-    <div>
+    <div className="home-page">
       <h1>Library</h1>
       <SearchBar />
-      <h2>Recent Changes</h2>
-      <ul>
-        {changes.map((c) => (
-          <li key={c.id}>
-            <Link to={`/book${c.data?.key || c.data?.works?.key || ''}`}>{c.comment || c.data?.title}</Link>
-          </li>
-        ))}
-      </ul>
+      <h2>Featured Books</h2>
+      <BookList books={books} />
     </div>
   );
 };

--- a/library-app/src/services/openLibrary.ts
+++ b/library-app/src/services/openLibrary.ts
@@ -53,3 +53,15 @@ export async function getWork(workKey: string) {
   const res = await axios.get(url);
   return res.data as Work;
 }
+
+export async function getSubjectBooks(subject: string, limit = 10) {
+  const url = `${BASE_URL}/subjects/${encodeURIComponent(subject)}.json?limit=${limit}`;
+  const res = await axios.get(url);
+  return (res.data.works as any[]).map((w) => ({
+    key: w.key,
+    title: w.title,
+    author_name: w.authors?.map((a: any) => a.name),
+    first_publish_year: w.first_publish_year,
+    cover_i: w.cover_id,
+  })) as Book[];
+}


### PR DESCRIPTION
## Summary
- add `getSubjectBooks` API helper
- show a featured book list on the home page
- apply basic styling for grid layout

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f55ce234832fae3fa8509d3d35f6